### PR TITLE
[Fix] - Single attribute with default value breaking on Ruby 3

### DIFF
--- a/lib/ez_attributes.rb
+++ b/lib/ez_attributes.rb
@@ -48,9 +48,7 @@ module EzAttributes
       end
 
       # Defines a single keyword argument for a class initializer
-      define_method :attribute do |*name, **name_with_default|
-        attributes(*name, **name_with_default)
-      end
+      alias_method :attribute, :attributes
     end
 
     mod

--- a/lib/ez_attributes.rb
+++ b/lib/ez_attributes.rb
@@ -48,8 +48,8 @@ module EzAttributes
       end
 
       # Defines a single keyword argument for a class initializer
-      define_method :attribute do |name|
-        attributes(name)
+      define_method :attribute do |*name, **name_with_default|
+        attributes(*name, **name_with_default)
       end
     end
 

--- a/spec/ez_attributes_spec.rb
+++ b/spec/ez_attributes_spec.rb
@@ -36,6 +36,41 @@ RSpec.describe EzAttributes do
     end
   end
 
+  context "when class has a single argument with a default value" do
+    let(:single_arg_class) do
+      Class.new do
+        extend EzAttributes
+
+        attribute a: 33
+      end
+    end
+
+    it "adds an initializer with a keyword argument" do
+      obj = single_arg_class.new(a: 1)
+
+      expect(obj).to be_instance_of single_arg_class
+    end
+
+    it "adds an attribute accessor" do
+      obj = single_arg_class.new(a: 1)
+
+      expect(obj.a).to eq(1)
+    end
+
+    it "uses the default value" do
+      obj = single_arg_class.new
+
+      expect(obj.a).to eq(33)
+    end
+
+    it "requires keyword args" do
+      expect { single_arg_class.new(1) }.to raise_error(
+        ArgumentError,
+        /wrong number of arguments \(given 1, expected 0\)/
+      )
+    end
+  end
+
   context "when class has multiple arguments" do
     let(:multiple_arg_class) do
       Class.new do

--- a/spec/ez_attributes_spec.rb
+++ b/spec/ez_attributes_spec.rb
@@ -36,41 +36,6 @@ RSpec.describe EzAttributes do
     end
   end
 
-  context "when class has a single argument with a default value" do
-    let(:single_arg_class) do
-      Class.new do
-        extend EzAttributes
-
-        attribute a: 33
-      end
-    end
-
-    it "adds an initializer with a keyword argument" do
-      obj = single_arg_class.new(a: 1)
-
-      expect(obj).to be_instance_of single_arg_class
-    end
-
-    it "adds an attribute accessor" do
-      obj = single_arg_class.new(a: 1)
-
-      expect(obj.a).to eq(1)
-    end
-
-    it "uses the default value" do
-      obj = single_arg_class.new
-
-      expect(obj.a).to eq(33)
-    end
-
-    it "requires keyword args" do
-      expect { single_arg_class.new(1) }.to raise_error(
-        ArgumentError,
-        /wrong number of arguments \(given 1, expected 0\)/
-      )
-    end
-  end
-
   context "when class has multiple arguments" do
     let(:multiple_arg_class) do
       Class.new do


### PR DESCRIPTION
Using EZAttributes on a Ruby 3 environment we are experimenting with this error:

![ez_attributes_ruby_3](https://user-images.githubusercontent.com/173159/145202623-45097736-688b-49ec-a6ec-7f738483c453.png)

It's happening because the attribute with default is going to the attributes method in the first arg...
On ruby 2 it's working well. However on Ruby 3, it´s being considered an required attribute, and is breaking because it does not have a required attribute format.