### PR TITLE
Ensure just one argument for EZAttributes#attribute method

### DIFF
--- a/lib/ez_attributes.rb
+++ b/lib/ez_attributes.rb
@@ -49,7 +49,14 @@ module EzAttributes
 
       # Defines a single keyword argument for a class initializer
       define_method :attribute do |name|
-        attributes(name)
+        if name.is_a?(Hash)
+          arguments = name.size
+          raise ArgumentError, "wrong number of arguments (given #{arguments}, expected 1)" if arguments != 1
+
+          attributes(**name)
+        else
+          attributes(name)
+        end
       end
     end
 

--- a/spec/ez_attributes_spec.rb
+++ b/spec/ez_attributes_spec.rb
@@ -36,6 +36,58 @@ RSpec.describe EzAttributes do
     end
   end
 
+  context "when class has a single argument with a default value" do
+    let(:single_arg_class) do
+      Class.new do
+        extend EzAttributes
+
+        attribute a: 33
+      end
+    end
+
+    it "adds an initializer with a keyword argument" do
+      obj = single_arg_class.new(a: 1)
+
+      expect(obj).to be_instance_of single_arg_class
+    end
+
+    it "adds an attribute accessor" do
+      obj = single_arg_class.new(a: 1)
+
+      expect(obj.a).to eq(1)
+    end
+
+    it "uses the default value" do
+      obj = single_arg_class.new
+
+      expect(obj.a).to eq(33)
+    end
+
+    it "requires keyword args" do
+      expect { single_arg_class.new(1) }.to raise_error(
+        ArgumentError,
+        /wrong number of arguments \(given 1, expected 0\)/
+      )
+    end
+  end
+
+  context "when class has a single argument with different of one default value" do
+    let(:single_arg_class) do
+      Class.new do
+        extend EzAttributes
+
+        attribute a: 33, b: 35
+      end
+    end
+
+    it "requires just one attribute" do
+      expect { single_arg_class.new(a: 1, b: 2) }.to raise_error(
+        ArgumentError,
+        /wrong number of arguments \(given 2, expected 1\)/
+      )
+    end
+  end
+
   context "when class has multiple arguments" do
     let(:multiple_arg_class) do
       Class.new do


### PR DESCRIPTION
On that PR https://github.com/MatheusRich/ez_attributes/pull/4, we discussed the EZAttributes#attribute method to be an independent method or a semantic alias attribute for the EZAttributes#attributes method.

Then, as an option for that one, we are proposing here a solution to strongly require one and just one attribute for that method.